### PR TITLE
Updated dependencies to LTS version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 - [Requirements](#requirements)
 - [Install](#install)
-- [Configure the API key](#api-key)
+- [Configure the INGESTION key](#ingestion_key)
 - [See official Documentation](https://docs.inspector.dev)
 
 <a name="requirements"></a>
 
 ## Requirements
 
-- PHP >= 7.1.3
-- Symfony >= 5
+- PHP >= 7.2.5
+- Symfony >= 5.2
 
 <a name="install"></a>
 
@@ -22,7 +22,7 @@ Install the latest version of our package by:
 composer require inspector-apm/inspector-symfony
 ```
 
-<a name="api-key"></a>
+<a name="ingestion_key"></a>
 
 ### Configure the INGESTION Key
 
@@ -30,10 +30,10 @@ Create the `inspector.yaml` configuration file in your `config/packages` directo
 
 ```yaml
 inspector:
-    api_key: [your-ingestion-key]
+    ingestion_key: [your-ingestion-key]
 ```
 
-You can obtain the `api_key` creating a new project in your [Inspector](https://www.inspector.dev) dashboard.
+You can obtain the `ingestion_key` creating a new project in your [Inspector](https://www.inspector.dev) dashboard.
 
 
 ## Official documentation

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-		"php": "^7.2.5",
+		"php": ">=7.2.5",
 		"inspector-apm/inspector-php": "^3.6",
         "symfony/config": "^5.2",
         "symfony/dependency-injection": "^5.2",

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
         }
     ],
     "require": {
-		"php": "^7.1.3",
-		"inspector-apm/inspector-php": "^3.5",
-        "symfony/config": "^5.0",
-        "symfony/dependency-injection": "^5.0",
-        "symfony/http-kernel": "^5.0",
-        "symfony/event-dispatcher": "^5.0",
-        "symfony/console": "^5.0"
+		"php": "^7.2.5",
+		"inspector-apm/inspector-php": "^3.6",
+        "symfony/config": "^5.2",
+        "symfony/dependency-injection": "^5.2",
+        "symfony/http-kernel": "^5.2",
+        "symfony/event-dispatcher": "^5.2",
+        "symfony/console": "^5.2"
 	},
     "require-dev": {
         "phpunit/phpunit": "^7.0",


### PR DESCRIPTION
Symfony components that are lower than `5.2` are not supported any more

TBD: probably we also need to support Symfony `4.4` as it's LTS version.