### PR TITLE
Code review updates

### DIFF
--- a/src/DependencyInjection/Compiler/DoctrineDBALCompilerPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineDBALCompilerPass.php
@@ -3,14 +3,13 @@
 namespace Inspector\Symfony\Bundle\DependencyInjection\Compiler;
 
 /** Compatibility with doctrine/dbal < 2.10.0 */
-
 use Doctrine\DBAL\Logging\LoggerChain;
 use Doctrine\DBAL\SQLParserUtils;
+/** End compatibility with doctrine/dbal < 2.10.0 */
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-/** End compatibility with doctrine/dbal < 2.10.0 */
 class DoctrineDBALCompilerPass implements CompilerPassInterface
 {
     /**

--- a/src/DependencyInjection/Compiler/DoctrineDBALCompilerPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineDBALCompilerPass.php
@@ -3,13 +3,14 @@
 namespace Inspector\Symfony\Bundle\DependencyInjection\Compiler;
 
 /** Compatibility with doctrine/dbal < 2.10.0 */
+
 use Doctrine\DBAL\Logging\LoggerChain;
 use Doctrine\DBAL\SQLParserUtils;
-/** End compatibility with doctrine/dbal < 2.10.0 */
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
+/** End compatibility with doctrine/dbal < 2.10.0 */
 class DoctrineDBALCompilerPass implements CompilerPassInterface
 {
     /**
@@ -17,6 +18,7 @@ class DoctrineDBALCompilerPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
+        //TODO: support multiple connections
         $logger = new Reference('doctrine.dbal.logger.inspectable');
         $chainLogger = $container->getDefinition('doctrine.dbal.logger.chain');
         if (! method_exists(SQLParserUtils::class, 'getPositionalPlaceholderPositions') && method_exists(LoggerChain::class, 'addLogger')) {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -24,7 +24,7 @@ class Configuration implements ConfigurationInterface
             ->booleanNode('query_bindings')->defaultFalse()->end()
             ->booleanNode('user')->defaultTrue()->end()
             ->scalarNode('transport')->defaultValue('async')->end()
-            ->floatNode('server_sampling_ratio')->defaultNull()->end()
+            ->floatNode('server_sampling_ratio')->default(0)->end()
             ->end();
 
         return $tree;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -24,7 +24,7 @@ class Configuration implements ConfigurationInterface
             ->booleanNode('query_bindings')->defaultFalse()->end()
             ->booleanNode('user')->defaultTrue()->end()
             ->scalarNode('transport')->defaultValue('async')->end()
-            ->floatNode('server_sampling_ratio')->default(0)->end()
+            ->floatNode('server_sampling_ratio')->defaultValue(0)->end()
             ->end();
 
         return $tree;

--- a/src/Inspectable/Doctrine/DBAL/Logging/InspectableSQLLogger.php
+++ b/src/Inspectable/Doctrine/DBAL/Logging/InspectableSQLLogger.php
@@ -8,8 +8,6 @@ use Inspector\Inspector;
 
 class InspectableSQLLogger implements SQLLogger
 {
-    protected const SEGMENT_TYPE = 'SQL';
-
     /** @var Inspector */
     protected $inspector;
 
@@ -34,7 +32,7 @@ class InspectableSQLLogger implements SQLLogger
      */
     public function startQuery($sql, ?array $params = null, ?array $types = null): void
     {
-        $this->segment = $this->inspector->startSegment(self::SEGMENT_TYPE, substr($sql, 0, 50));
+        $this->segment = $this->inspector->startSegment('SQL', substr($sql, 0, 50));
 
         $context = ['sql' => $sql];
 

--- a/src/Inspectable/Doctrine/DBAL/Logging/InspectableSQLLogger.php
+++ b/src/Inspectable/Doctrine/DBAL/Logging/InspectableSQLLogger.php
@@ -34,23 +34,17 @@ class InspectableSQLLogger implements SQLLogger
      */
     public function startQuery($sql, ?array $params = null, ?array $types = null): void
     {
-        $label = substr($sql, 0, 50).'...';
-        $this->segment = $this->inspector->startSegment(self::SEGMENT_TYPE, $label);
+        $this->segment = $this->inspector->startSegment(self::SEGMENT_TYPE, substr($sql, 0, 50));
 
-        // TODO: connection name
-        $context = [];
+        $context = ['sql' => $sql];
 
-        // Checks if option is set and is convertable to true
-        if (!empty($this->configuration['query_bindings'])) {
-            $context['sql'] = $sql;
-        }
-
-        // Checks if option is set and is convertable to true
+        // Checks if option is set and is convertible to true
         if (!empty($this->configuration['query_bindings'])) {
             $context['bindings'] = $params;
         }
 
-        $this->segment->addContext($label, $context);
+        // TODO: connection name
+        $this->segment->addContext('DB', $context);
     }
 
     /**

--- a/src/Inspectable/Doctrine/DBAL/Logging/InspectableSQLLogger.php
+++ b/src/Inspectable/Doctrine/DBAL/Logging/InspectableSQLLogger.php
@@ -32,6 +32,7 @@ class InspectableSQLLogger implements SQLLogger
      */
     public function startQuery($sql, ?array $params = null, ?array $types = null): void
     {
+        // TODO: connection name
         $this->segment = $this->inspector->startSegment('SQL', substr($sql, 0, 50));
 
         $context = ['sql' => $sql];
@@ -41,7 +42,6 @@ class InspectableSQLLogger implements SQLLogger
             $context['bindings'] = $params;
         }
 
-        // TODO: connection name
         $this->segment->addContext('DB', $context);
     }
 

--- a/src/Listeners/ConsoleEventsSubscriber.php
+++ b/src/Listeners/ConsoleEventsSubscriber.php
@@ -49,9 +49,16 @@ class ConsoleEventsSubscriber implements EventSubscriberInterface
      */
     public function onConsoleStart(ConsoleCommandEvent $event): void
     {
-        $this->startTransaction($event->getCommand()->getName());
-
-        $this->startSegment(self::SEGMENT_TYPE_PROCESS, self::LABEL_COMMAND_EXECUTION);
+        $commandName = $event->getCommand()->getName();
+        if ($this->inspector->needTransaction()) {
+            $this->inspector->startTransaction($commandName)
+                ->addContext('Command', [
+                    'arguments' => $event->getInput()->getArguments(),
+                    'options' => $event->getInput()->getOptions(),
+                ]);
+        } elseif ($this->inspector->canAddSegments()) {
+            $this->segments[$commandName] = $this->inspector->startSegment('command', $commandName);
+        }
     }
 
     /**
@@ -61,20 +68,31 @@ class ConsoleEventsSubscriber implements EventSubscriberInterface
      */
     public function onConsoleError(ConsoleErrorEvent $event): void
     {
-        $this->inspector->currentTransaction()->setResult('error');
+        if ($this->inspector->canAddSegments()) {
+            $this->inspector->currentTransaction()->setResult('error');
+        }
 
         $this->notifyUnexpectedError($event->getError());
     }
 
     public function onConsoleTerminate(ConsoleTerminateEvent $event): void
     {
-        $this->endSegment(self::LABEL_COMMAND_EXECUTION);
+        $commandName = $event->getCommand()->getName();
+        if($this->inspector->hasTransaction() && $this->inspector->currentTransaction()->name === $commandName) {
+            $this->inspector->currentTransaction()->setResult($event->exitCode === 0 ? 'success' : 'error');
+        } elseif(array_key_exists($commandName, $this->segments)) {
+            $this->segments[$commandName]->end()->addContext('Command', [
+                'exit_code' => $event->getExitCode(),
+                'arguments' => $event->getInput()->getArguments(),
+                'options' => $event->getInput()->getOptions(),
+            ]);
+        }
     }
 
     public function onConsoleSignal(ConsoleSignalEvent $event): void
     {
-        $this->inspector->currentTransaction()->setResult('terminated');
-
-        $this->endSegment(self::LABEL_COMMAND_EXECUTION);
+        if ($this->inspector->canAddSegments()) {
+            $this->inspector->currentTransaction()->setResult('terminated');
+        }
     }
 }

--- a/src/Listeners/ConsoleEventsSubscriber.php
+++ b/src/Listeners/ConsoleEventsSubscriber.php
@@ -76,7 +76,7 @@ class ConsoleEventsSubscriber implements EventSubscriberInterface
     {
         $commandName = $event->getCommand()->getName();
         if($this->inspector->hasTransaction() && $this->inspector->currentTransaction()->name === $commandName) {
-            $this->inspector->currentTransaction()->setResult($event->exitCode === 0 ? 'success' : 'error');
+            $this->inspector->currentTransaction()->setResult($event->getExitCode() === 0 ? 'success' : 'error');
         } elseif(array_key_exists($commandName, $this->segments)) {
             $this->segments[$commandName]->end()->addContext('Command', [
                 'exit_code' => $event->getExitCode(),

--- a/src/Listeners/ConsoleEventsSubscriber.php
+++ b/src/Listeners/ConsoleEventsSubscriber.php
@@ -14,9 +14,6 @@ class ConsoleEventsSubscriber implements EventSubscriberInterface
 {
     use InspectorAwareTrait;
 
-    protected const SEGMENT_TYPE_PROCESS = 'process';
-    protected const LABEL_COMMAND_EXECUTION = 'Command Execution';
-
     public function __construct(Inspector $inspector)
     {
         $this->inspector = $inspector;

--- a/src/Listeners/KernelEventsSubscriber.php
+++ b/src/Listeners/KernelEventsSubscriber.php
@@ -151,7 +151,7 @@ class KernelEventsSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $this->startTransaction($event->getRequest()->getMethod() . ' ' . $this->routeName);
+        $this->startTransaction($event->getRequest()->getMethod() . ' /' . $this->routeName);
 
         $this->startSegment(self::SEGMENT_TYPE_PROCESS, KernelEvents::REQUEST);
     }


### PR DESCRIPTION
- server_sample_ratio explicitly zero
- use string instead of segment_type
- use labels in sql  logger
- use connection name as segment type
- remove segment from command
- ! Identify when console command can bee present as a transaction or segment  https://github.com/inspector-apm/inspector-laravel/blob/master/src/Providers/CommandServiceProvider.php
- add slash to the route name