### PR TITLE
if inspector is disabled, still load the services

### DIFF
--- a/src/DependencyInjection/InspectorExtension.php
+++ b/src/DependencyInjection/InspectorExtension.php
@@ -36,7 +36,7 @@ class InspectorExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
         $container->setParameter('inspector.configuration.definition', $config);
 
-        if(true !== $config['enabled'] || empty($config['ingestion_key'])) {
+        if(empty($config['ingestion_key'])) {
             return;
         }
 


### PR DESCRIPTION
If the we use Inspector\Inspector as a dependency for other services, for example to add segments, and we disabled inspector for test or staging environments the Inspector\Inspector service won't be available.

So they need to be created, but I see that the enabled config is also stored in the Inspector service, so the services can be created, but they wont record stuff I guess?

