### PR TITLE
Update Symfony dependencies for PHP 8.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,23 +14,23 @@
     "require": {
 		"php": ">=8.0",
 		"inspector-apm/inspector-php": "^3.11",
-        "symfony/config": "^5.2|^6.0|^7.0",
-        "symfony/dependency-injection": "^5.2|^6.0|^7.0",
-        "symfony/http-kernel": "^5.2|^6.0|^7.0",
-        "symfony/event-dispatcher": "^5.2|^6.0|^7.0",
-        "symfony/console": "^5.2|^6.0|^7.0",
-        "symfony/framework-bundle": "^5.2|^6.0|^7.0",
-        "symfony/yaml": "^5.2|^6.0|^7.0"
+        "symfony/config": "^5.2|^6.0|^7.0|^8.0",
+        "symfony/dependency-injection": "^5.2|^6.0|^7.0|^8.0",
+        "symfony/http-kernel": "^5.2|^6.0|^7.0|^8.0",
+        "symfony/event-dispatcher": "^5.2|^6.0|^7.0|^8.0",
+        "symfony/console": "^5.2|^6.0|^7.0|^8.0",
+        "symfony/framework-bundle": "^5.2|^6.0|^7.0|^8.0",
+        "symfony/yaml": "^5.2|^6.0|^7.0|^8.0"
 	},
     "require-dev": {
-        "doctrine/doctrine-bundle": "^2.4",
+        "doctrine/doctrine-bundle": "^2.4|^3.0",
         "phpunit/phpunit": "^9.5",
-        "symfony/doctrine-messenger": "^5.2|^6.0|^7.0",
-        "symfony/mailer": "^5.2|^6.0|^7.0",
-        "symfony/notifier": "^5.2|^6.0|^7.0",
-        "symfony/security-bundle": "^5.2|^6.0|^7.0",
+        "symfony/doctrine-messenger": "^5.2|^6.0|^7.0|^8.0",
+        "symfony/mailer": "^5.2|^6.0|^7.0|^8.0",
+        "symfony/notifier": "^5.2|^6.0|^7.0|^8.0",
+        "symfony/security-bundle": "^5.2|^6.0|^7.0|^8.0",
         "symfony/test-pack": "^1.0",
-        "symfony/messenger": "^5.2|^6.0|^7.2"
+        "symfony/messenger": "^5.2|^6.0|^7.2|^8.0"
     },
 	"autoload": {
         "psr-4": {


### PR DESCRIPTION
Updated Symfony package versions to support 8.0, which was released a few days ago.